### PR TITLE
複数スケジュール編集が反映されない問題の修正 & 日付処理関数を date.js に統合

### DIFF
--- a/frontend/src/pages/schedules/DatesModal.jsx
+++ b/frontend/src/pages/schedules/DatesModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import "./DatesModal.css";
+import { formatDateTime } from "../../utils/date";
 
 export default function ScheduleDatesModal({ dates, removeDate, onClose }) {
   // 以下のコードとeffectはdates配列の中身が1になった時に削除を押せないようにする目的
@@ -21,9 +22,11 @@ export default function ScheduleDatesModal({ dates, removeDate, onClose }) {
         {dates.map((date, index) => (
           <div key={index} className="dates-modal-card">
             <div style={{ display: "block", marginBottom: "4px" }}>
-              開始: {date.start_date || "-"}
+              開始: {formatDateTime(date.start_date || "-", "datetime")}
             </div>
-            <div style={{ display: "block" }}>終了: {date.end_date || "-"}</div>
+            <div style={{ display: "block" }}>
+              終了: {formatDateTime(date.end_date || "-", "datetime")}
+            </div>
             <button
               type="button"
               onClick={() => removeDate(index)}

--- a/frontend/src/pages/schedules/useDateTime.js
+++ b/frontend/src/pages/schedules/useDateTime.js
@@ -1,25 +1,9 @@
 import { useState, useEffect } from "react";
+import { getNowDateTime, getNowPlusOneHour } from "../../utils/date";
 
 export function useDateTime(schedules) {
   const [selectedDate, setSelectedDate] = useState(null);
   const [events, setEvents] = useState([]);
-
-  // --- 日付補助関数 ---
-  function getNowDateTime() {
-    const now = new Date();
-    now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
-    return now.toISOString().slice(0, 16);
-  }
-
-  function getNowPlusOneHour() {
-    const now = new Date();
-    now.setMinutes(now.getMinutes() - now.getTimezoneOffset() + 60);
-    return now.toISOString().slice(0, 16);
-  }
-
-  const handleDateClick = (info) => {
-    setSelectedDate(info.dateStr);
-  };
 
   useEffect(() => {
     if (!schedules) {
@@ -46,26 +30,19 @@ export function useDateTime(schedules) {
     selectedDate,
     setSelectedDate,
     events,
-    handleDateClick,
-    getNowDateTime,
-    getNowPlusOneHour,
   };
 }
 
-
-
 // scheduleのdatesに追加するための関数
-// 
+//
 export function handleDateTime(formData, onChange) {
-  const { getNowDateTime, getNowPlusOneHour } = useDateTime();
-
   const [dates, setDates] = useState(
     formData.dates && formData.dates.length > 0
       ? formData.dates
       : [{ start_date: "", end_date: "" }]
   );
-  const [tempStart, setTempStart] = useState(getNowDateTime);
-  const [tempEnd, setTempEnd] = useState(getNowPlusOneHour);
+  const [tempStart, setTempStart] = useState(getNowDateTime());
+  const [tempEnd, setTempEnd] = useState(getNowPlusOneHour());
 
   const [datesDisable, setDatesDisable] = useState(false);
 
@@ -99,17 +76,14 @@ export function handleDateTime(formData, onChange) {
   };
 
   useEffect(() => {
-    if (
+    const invalid =
       !tempStart ||
-      (!tempEnd &&
-        tempStart >= tempEnd &&
-        dates.some((date) => date.start_date === newDate.start_date))
-    ) {
-      setDatesDisable(true);
-    } else {
-      setDatesDisable(false);
-    }
-  }, []);
+      !tempEnd ||
+      tempStart >= tempEnd ||
+      dates.some((date) => date.start_date === tempStart);
+
+    setDatesDisable(invalid);
+  }, [tempStart, tempEnd, dates]);
 
   const removeDate = (index) => {
     const newDates = dates.filter((_, i) => i !== index);

--- a/frontend/src/pages/schedules/useSchedule.js
+++ b/frontend/src/pages/schedules/useSchedule.js
@@ -4,6 +4,7 @@ import { useAuth } from "../../context/AuthContext";
 import { apiFetch } from "../../api/client";
 import { useCategory } from "../categories/categoryHandlers";
 import { useDateTime } from "../schedules/useDateTime";
+import { getNowDateTime, getNowPlusOneHour } from "../../utils/date";
 
 export function useSchedule(id = null) {
   const { accessToken, refreshToken, handleRefresh } = useAuth();
@@ -13,14 +14,8 @@ export function useSchedule(id = null) {
 
   const { fetchCategories } = useCategory();
 
-  const {
-    selectedDate,
-    selectedDates,
-    setSelectedDate,
-    setSelectedDates,
-    getNowDateTime,
-    getNowPlusOneHour,
-  } = useDateTime(schedules);
+  const { selectedDate, selectedDates, setSelectedDates } =
+    useDateTime(schedules);
 
   const [isCreating, setIsCreating] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
@@ -92,16 +87,27 @@ export function useSchedule(id = null) {
   // --- 更新 ---
   const handleScheduleUpdate = async (e) => {
     e.preventDefault();
+
+    const payload = {
+      ...formData,
+      dates: formData.dates.map((d) => ({
+        id: d.id || crypto.randomUUID(), // ← idを維持または生成
+        start_date: d.start_date,
+        end_date: d.end_date,
+      })),
+    };
+
     await apiFetch(
       `${base_url}${id}`,
       {
         method: "PUT",
-        body: JSON.stringify(formData),
+        body: JSON.stringify(payload),
       },
       { accessToken, refreshToken, handleRefresh }
     );
     await fetchSchedule();
     setIsEditMode(false);
+    alert("スケジュールを更新しました");
   };
 
   // --- 削除 ---

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -31,3 +31,32 @@ formatDatePart(isoString, "datetime") // 年月日時分を返す（デフォル
 formatDatePart(isoString, "date")     // 年月日を返す
 formatDatePart(isoString, "time")     // 時分のみを返す
 */
+
+// --- 日付補助関数 ---
+// SafariでtoISOString()を使うとUTCに変換されてしまい、
+// <input type="datetime-local"> にセットできなくなる。
+// そこで、手動で「YYYY-MM-DDTHH:mm」形式の文字列を作る。
+//
+// 重複処理をまとめた共通関数
+// → どんなDateオブジェクトでも安全にローカル時刻フォーマットできる
+function formatLocalDateTime(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+export function getNowDateTime() {
+  // 現在時刻をローカルフォーマットで返す
+  const now = new Date();
+  return formatLocalDateTime(now);
+}
+
+export function getNowPlusOneHour() {
+  // 現在時刻＋1時間をローカルフォーマットで返す
+  const now = new Date();
+  now.setHours(now.getHours() + 1);
+  return formatLocalDateTime(now);
+}


### PR DESCRIPTION
① 複数スケジュールの編集が反映されない問題
	•	フロントエンドから PUT リクエストを送信しても、

DB上で schedule_dates の更新・追加・削除が反映されなかった。
	•	FastAPI は 200 OK を返すが、SQLAlchemy が UPDATE / INSERT / DELETE を発行していなかった。
	•	原因は crud/schedule.py の update() 関数が

Pydanticモデル (ScheduleDateBase) を直接操作しており、ORMが変更を検知できなかった こと。

	•	.model_dump(exclude_unset=True) を使用して、送信されていない値を上書きしないようにした。
	•	SQLAlchemy のトラッキングが確実に機能し、UPDATE / INSERT / DELETE がDBに反映されるように修正。
	•	既存データの更新・新規追加・削除のすべてを正しく処理可能。

✅ 結果
	•	PUT リクエスト後に DB 状態が正しく反映。
	•	これまで反映されなかった複数日付の編集が正常に動作。

２つ目は日付に関する関数をdate.jsに移行。

対象: frontend/src/utils/date.js

変更前
	•	各ページ内で getNowDateTime() や getNowPlusOneHour() を重複定義。
	•	Safariで toISOString() を使用すると UTC に変換されてしまう問題があった。

変更後
	•	重複部分を共通化し、date.js にまとめた。
	•	"YYYY-MM-DDTHH:mm" 形式を手動で生成することで、ブラウザ間のズレを防止。

✅ 結果
	•	全ブラウザで日付入力・表示が安定。
	•	コード重複を排除し、可読性・保守性が向上。