### PR TITLE
リファクタリング：CRUD更新処理を共通化（model_dump + setter 導入）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ Thumbs.db
 .vscode/
 .idea/
 
+# Makefile
+Makefile

--- a/backend/app/api/category.py
+++ b/backend/app/api/category.py
@@ -27,10 +27,9 @@ def list_categories(
 def create_category(
     category_in: CategoryCreate,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
 ):
     repo = CategoryRepository(db)
-    return repo.create(user_id=current_user.id, category_in=category_in)
+    return repo.create(category_in=category_in)
 
 
 # --- 更新 ---

--- a/backend/app/api/todo.py
+++ b/backend/app/api/todo.py
@@ -41,7 +41,7 @@ def create_todo(
         raise HTTPException(status_code=403, detail="権限がありません")
 
     repo = TodoRepository(db)
-    return repo.create(schedule_id, todo_in)
+    return repo.create(todo_in)
 
 
 # --- Todo 更新 ---

--- a/backend/app/crud/base.py
+++ b/backend/app/crud/base.py
@@ -56,3 +56,20 @@ class BaseRepository:
             return obj
         except Exception:
             return None
+
+    def base_apply_schema(self, obj, schema_in, exclude: set[str] | None = None):
+        """
+        Pydanticモデル(schema_in)のデータをSQLAlchemyモデル(obj)へ安全に適用する。
+        exclude_unset=True で部分更新を行い、ifhasattr(obj,key)で存在しない属性は無視。
+        """
+        data = schema_in.model_dump(exclude_unset=True, exclude=exclude or set())
+
+        for key, value in data.items():
+            # None はリレーション破壊を防ぐためスキップ
+            if value is None:
+                continue
+
+            if hasattr(obj, key):
+                setattr(obj, key, value)
+
+        return obj

--- a/backend/app/crud/base.py
+++ b/backend/app/crud/base.py
@@ -57,6 +57,26 @@ class BaseRepository:
         except Exception:
             return None
 
+    def base_create_instance(self, model, schema_in):
+        """
+        任意のモデルに対応できる共通「新規作成」関数
+
+        【目的】
+        - Pydanticモデル(schema_in) から SQLAlchemyモデル(model_class) を安全に作成する。
+        - 各モデルのカラムが変わっても、この関数を修正する必要がない。
+
+        【実現方法】
+        - model_dump() で Pydanticモデルを dict に変換。
+        - model_validate() で SQLAlchemyモデルを検証付きで生成。
+        ※ Pydantic v2では model_validate() を使うことで、型変換や検証が自動で行われる。
+        - 最後にDBに追加してコミット。
+        """
+        data = schema_in.model_dump()
+
+        obj = model.model_validate(data)
+
+        return obj
+
     def base_apply_schema(self, obj, schema_in, exclude: set[str] | None = None):
         """
         Pydanticモデル(schema_in)のデータをSQLAlchemyモデル(obj)へ安全に適用する。

--- a/backend/app/crud/baserepository.md
+++ b/backend/app/crud/baserepository.md
@@ -3,23 +3,17 @@
 本リポジトリは、SQLAlchemy を利用した CRUD 処理を共通化するための基底クラスです。  
 FastAPI などのアプリケーションで、モデルごとの Repository を実装する際の土台として利用します。
 
----
-
 ## ✅ 目的
 
 - CRUD の共通処理をまとめて重複を減らす
 - 例外発生時やデータ未存在時の返り値を統一する
 - ビジネスロジックは各モデル専用の Repository に記述し、BaseRepository は最低限の共通処理のみを担当する
 
----
-
 ## ✅ 使用方法
 
 1. Repository クラスを作成し、BaseRepository を継承する
 2. `db` (Session) と `model` (SQLAlchemy モデルクラス) を渡して初期化する
 3. CRUD メソッドを呼び出す
-
----
 
 ## ✅ 実装されているメソッド
 
@@ -52,7 +46,11 @@ FastAPI などのアプリケーションで、モデルごとの Repository を
 - 成功時 → 更新後の `obj`
 - obj が `None` または失敗時 → `None`
 
----
+### apply_schema(obj, schema_in, exclude: set[str] | None = None)
+
+- モデル -> dict 変換
+- schema_in には該当の pydict スキーマを挿入
+- exclude には除外したい項目を挿入
 
 ## ✅ 注意点
 
@@ -60,8 +58,6 @@ FastAPI などのアプリケーションで、モデルごとの Repository を
   - Web API で利用する際は、ルーター層で `404` や `400` に変換する
 - **ビジネスロジック**（例: パスワードハッシュ化, Todo 完了時の done_at 付与）は BaseRepository には書かない
   - 各モデル専用の Repository に実装する
-
----
 
 ## ✅ 想定される利用例
 

--- a/backend/app/crud/category.py
+++ b/backend/app/crud/category.py
@@ -10,12 +10,9 @@ class CategoryRepository(BaseRepository):
         super().__init__(db, Category)
 
     # --- 作成 ---
-    def create(self, user_id: UUID, category_in: CategoryCreate) -> Category:
-        category = Category(
-            user_id=user_id,
-            name=category_in.name,
-            color=category_in.color.value,  # Enum → str
-        )
+    def create(self, category_in: CategoryCreate) -> Category:
+        category = self.base_create_instance(model=Category, schema_in=category_in)
+
         return self.base_add(category)
 
     # --- 取得（ID指定） ---

--- a/backend/app/crud/category.py
+++ b/backend/app/crud/category.py
@@ -43,9 +43,8 @@ class CategoryRepository(BaseRepository):
         if not category:
             return None
 
-        if category_in.name is not None:
-            category.name = category_in.name
-        if category_in.color is not None:
-            category.color = category_in.color.value
+        self.base_apply_schema(
+            obj=category, schema_in=category_in, exclude={"id", "user_id"}
+        )
 
         return self.base_update(category)  # ここで commit + refresh 済み

--- a/backend/app/crud/schedule.py
+++ b/backend/app/crud/schedule.py
@@ -10,6 +10,7 @@ class ScheduleRepository(BaseRepository):
         super().__init__(db, Schedule)
 
     # --- 作成 ---
+    # スケジュールの予定はdatesモデルも絡んでいるため、base_create_instanceの導入は見送り
     def create(self, user_id: UUID, schedule_in: ScheduleCreate) -> Schedule:
         schedule = Schedule(
             title=schedule_in.title,

--- a/backend/app/crud/schedule.py
+++ b/backend/app/crud/schedule.py
@@ -48,11 +48,9 @@ class ScheduleRepository(BaseRepository):
     """
 
     def _update_schedule_fields(self, schedule: Schedule, schedule_in: ScheduleUpdate):
-        update_data = schedule_in.model_dump(exclude={"id", "user_id", "dates"})
-
-        # --- ① 日付データ以外の更新処理 ---
-        for field, value in update_data.items():
-            setattr(schedule, field, value)
+        self.base_apply_schema(
+            obj=schedule, schema_in=schedule_in, exclude={"id", "user_id", "dates"}
+        )
 
     def _update_schedule_dates(
         self, schedule: Schedule, schedule_in: ScheduleUpdate, schedule_id: UUID
@@ -67,18 +65,8 @@ class ScheduleRepository(BaseRepository):
         for date_id, date_in in incoming_dates.items():
             if date_id in existing_dates:
                 existing_date = existing_dates[date_id]
+                self.base_apply_schema(obj=existing_date, schema_in=date_in)
 
-                # --- 💡 Pydantic → dict 変換 ---
-                # model_dump() を使う理由:
-                #   PydanticモデルのままだとSQLAlchemyが直接理解できないため、
-                #   素のPython辞書に変換してからSQLAlchemyモデルに値を代入する。
-                # exclude_unset=True により「未送信フィールド」は上書きされない。
-                date_data = date_in.model_dump(exclude_unset=True)
-
-                # --- 💡 SQLAlchemyモデルに代入 ---
-                # setattr() によって SQLAlchemy が変更を検知し、UPDATE を発行する。
-                for key, value in date_data.items():
-                    setattr(existing_date, key, value)
             else:
                 # 新規追加
                 # --- 💡 新しいScheduleDateインスタンスを作成し、ORMで追跡させる ---

--- a/backend/app/crud/todo.py
+++ b/backend/app/crud/todo.py
@@ -11,14 +11,8 @@ class TodoRepository(BaseRepository):
         super().__init__(db, Todo)
 
     # --- 作成 ---
-    def create(self, schedule_id: UUID, todo_in: TodoCreate) -> Todo:
-        todo = Todo(
-            title=todo_in.title,
-            is_done=todo_in.is_done,
-            priority=todo_in.priority,
-            due_date=todo_in.due_date,
-            schedule_id=schedule_id,
-        )
+    def create(self, todo_in: TodoCreate) -> Todo:
+        todo = self.base_create_instance(model=Todo, schema_in=todo_in)
         return self.base_add(todo)
 
     # --- 取得（ID指定） ---

--- a/backend/app/crud/todo.py
+++ b/backend/app/crud/todo.py
@@ -44,6 +44,7 @@ class TodoRepository(BaseRepository):
 
         update_data = schedule_in.model_dump(exclude_unset=True)
 
+        # 現場todoはis_done以外にフィールドの変更ができない状態のでここのbase_apply_schemaの適用を除外
         for field, value in update_data.items():
             if field == "is_done":
                 todo.is_done = value


### PR DESCRIPTION
🧾 概要（Description）

PydanticモデルからSQLAlchemyモデルへの更新処理を共通化しました。
これまで各CRUD関数で obj.field = in_data.field のように個別更新していた箇所をmodel_dump(exclude_unset=True) + setter() を利用した共通関数を利用する形式に変更しました。
BaseRepositoryにbase_apply_schema()を追加し各編集の箇所をこれに置き換えました。


これにより以下の点が期待できます。

- 	✅ コードの重複削減
- 	✅ モデル構造変更への耐性向上
- 	✅ None やリレーション更新の安全性確保
 
