### PR TITLE
スケジュール詳細ページの日時カードのレイアウト変更(#1[v1.2.0])

### DIFF
--- a/frontend/src/components/card/dates/DateTimeCard.jsx
+++ b/frontend/src/components/card/dates/DateTimeCard.jsx
@@ -1,0 +1,65 @@
+// DateTimeCard.jsx
+import { useState } from "react";
+import TimePicker from "../../commonPicker/TimePicker";
+import "./dateTimeCard.css";
+import {
+  formatDate,
+  normalizeDates,
+  getVisibleDates,
+} from "./dateTimeCardLogic";
+
+export function DateTimeCard({ timeGroup }) {
+  const dates = normalizeDates(timeGroup?.dates);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div className="date-card">
+      {/* 時刻帯 */}
+      <div className="section">
+        <div className="section-title">⏰ 時刻帯</div>
+
+        <div className="time-row">
+          <div className="label">開始</div>
+          <span className="time-text">{timeGroup.start}</span>
+        </div>
+
+        <div className="time-row">
+          <div className="label">終了</div>
+          <span className="time-text">{timeGroup.end}</span>
+        </div>
+      </div>
+
+      {/* 日付一覧 */}
+      <div className="section">
+        <div className="section-title">📅 対象日</div>
+
+        {dates.length > 0 ? (
+          (() => {
+            const { visible, rest } = getVisibleDates(dates);
+            const shownDates = isExpanded ? dates : visible;
+
+            return (
+              <ul className="date-list">
+                {shownDates.map((d) => (
+                  <li
+                    key={d.id}
+                    className={
+                      d.isPast ? "date-item date-item--past" : "date-item"
+                    }
+                  >
+                    {formatDate(d.date)}
+                  </li>
+                ))}
+                {!isExpanded && rest > 0 && (
+                  <li onClick={() => setIsExpanded(true)}>…その他 {rest} 件</li>
+                )}
+              </ul>
+            );
+          })()
+        ) : (
+          <p>日程はまだ登録されていません。</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/card/dates/dateTimeCard.css
+++ b/frontend/src/components/card/dates/dateTimeCard.css
@@ -1,0 +1,70 @@
+/* dateTimeCard.css */
+
+.date-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.section {
+  margin-bottom: 12px;
+}
+
+.section-title {
+  font-size: 13px;
+  color: #555;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.time-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.label {
+  width: 48px;
+  font-size: 14px;
+  color: #333;
+}
+
+.time-button {
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  background: #f9fafb;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.time-text {
+  font-size: 14px;
+  color: #222;
+}
+
+.date-list {
+  padding-left: 18px;
+  margin: 0;
+}
+
+.date-list li {
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+/* dateTimeCard.css */
+.date-item {
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.date-item--past {
+  color: #999;
+  opacity: 0.6;
+}

--- a/frontend/src/components/card/dates/dateTimeCardLogic.js
+++ b/frontend/src/components/card/dates/dateTimeCardLogic.js
@@ -1,0 +1,26 @@
+// dateTimeCardLogic.js
+
+/**
+ * YYYY-MM-DD → 「M月D日」
+ */
+export function formatDate(isoDate) {
+  const d = new Date(isoDate);
+  return `${d.getMonth() + 1}月${d.getDate()}日`;
+}
+
+/**
+ * dates の安全化
+ */
+export function normalizeDates(dates) {
+  return Array.isArray(dates) ? dates : [];
+}
+
+/**
+ * 最大表示数を超えた場合の制御
+ */
+export function getVisibleDates(dates, max = 5) {
+  return {
+    visible: dates.slice(0, max),
+    rest: Math.max(dates.length - max, 0),
+  };
+}

--- a/frontend/src/components/card/dates/scheduleViewAdapter.js
+++ b/frontend/src/components/card/dates/scheduleViewAdapter.js
@@ -1,0 +1,58 @@
+// scheduleViewAdapter.js
+
+function splitISODateTime(iso) {
+  const [date, timeWithSec] = iso.split("T");
+  return {
+    date, // YYYY-MM-DD
+    time: timeWithSec.slice(0, 5), // HH:mm
+  };
+}
+
+function getTodayISODate() {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * pastPolicy:
+ *  - "hide"      : 過去日付を除外
+ *  - "show"      : すべて表示
+ *  - "gray"      : フラグ付与（UI側で制御）
+ */
+export function buildTimeGroupsFromDates(apiDates, pastPolicy = "hide") {
+  if (!Array.isArray(apiDates)) return [];
+
+  const today = getTodayISODate();
+  const map = new Map();
+
+  apiDates.forEach((d) => {
+    const start = splitISODateTime(d.start_date);
+    const end = splitISODateTime(d.end_date);
+
+    const isPast = start.date < today;
+
+    // hide の場合のみここで除外
+    if (pastPolicy === "hide" && isPast) return;
+
+    const key = `${start.time}-${end.time}`;
+
+    if (!map.has(key)) {
+      map.set(key, {
+        start: start.time,
+        end: end.time,
+        dates: [],
+      });
+    }
+
+    map.get(key).dates.push({
+      id: d.id,
+      date: start.date,
+      isPast, // show / gray / collapse 用
+    });
+  });
+
+  return Array.from(map.values()).filter((tg) => tg.dates.length > 0);
+}

--- a/frontend/src/components/card/schedule/ScheduleCard.jsx
+++ b/frontend/src/components/card/schedule/ScheduleCard.jsx
@@ -10,6 +10,8 @@ import { Button } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 
 import CardContainer from "../common/CardContainer";
+import { DateTimeCard } from "../dates/DateTimeCard";
+import { buildTimeGroupsFromDates } from "../dates/scheduleViewAdapter";
 
 export default function ScheduleCard({
   schedule,
@@ -88,7 +90,12 @@ export default function ScheduleCard({
 
       <h3>予定の日にち一覧</h3>
       {Array.isArray(schedule?.dates) && schedule.dates.length > 0 ? (
-        schedule.dates.map((d) => <ScheduleDatesCard key={d.id} date={d} />)
+        buildTimeGroupsFromDates(schedule.dates, "gray").map((timeGroup) => (
+          <DateTimeCard
+            key={`${timeGroup.start}-${timeGroup.end}`}
+            timeGroup={timeGroup}
+          />
+        ))
       ) : (
         <p>日程はまだ登録されていません。</p>
       )}

--- a/frontend/src/components/commonPicker/TimePicker.jsx
+++ b/frontend/src/components/commonPicker/TimePicker.jsx
@@ -1,6 +1,40 @@
 import { TIME_OPTIONS } from "./timeOptions";
 import { getConstraints } from "./timeConstraints";
 
+const styles = {
+  row: {
+    display: "flex",
+    alignItems: "center",
+    gap: "12px",
+    marginBottom: "12px",
+  },
+  label: {
+    width: "48px",
+    fontSize: "14px",
+  },
+  pickerWrapper: {
+    flex: 1,
+    position: "relative",
+  },
+  select: {
+    width: "100%",
+    height: "42px",
+    padding: "0 36px 0 12px",
+    borderRadius: "10px",
+    border: "1px solid #ddd",
+    appearance: "none",
+    cursor: "pointer",
+  },
+  arrow: {
+    position: "absolute",
+    right: "12px",
+    top: "50%",
+    transform: "translateY(-50%)",
+    fontSize: "10px",
+    pointerEvents: "none",
+  },
+};
+
 export default function TimePicker({
   label,
   value,
@@ -36,37 +70,3 @@ export default function TimePicker({
     </div>
   );
 }
-
-const styles = {
-  row: {
-    display: "flex",
-    alignItems: "center",
-    gap: "12px",
-    marginBottom: "12px",
-  },
-  label: {
-    width: "48px",
-    fontSize: "14px",
-  },
-  pickerWrapper: {
-    flex: 1,
-    position: "relative",
-  },
-  select: {
-    width: "100%",
-    height: "42px",
-    padding: "0 36px 0 12px",
-    borderRadius: "10px",
-    border: "1px solid #ddd",
-    appearance: "none",
-    cursor: "pointer",
-  },
-  arrow: {
-    position: "absolute",
-    right: "12px",
-    top: "50%",
-    transform: "translateY(-50%)",
-    fontSize: "10px",
-    pointerEvents: "none",
-  },
-};


### PR DESCRIPTION
# 日時カートのレイアウト変更

## 1. 行なったこと

日時カードのレイアウトを変更しました

---
## 2. 変更内容
- dateを一つづつ取り出していたものを、時刻で分ける
- 時刻を起点に、それで行われる日程をリスト形式で表示
--- 
## 3. 期待効果

スクロール量の削減

--- 