### PR TITLE
日付一覧モーダルで編集ができるようにした

### DIFF
--- a/frontend/src/pages/schedules/DatesModal.jsx
+++ b/frontend/src/pages/schedules/DatesModal.jsx
@@ -1,42 +1,98 @@
 import { useState, useEffect } from "react";
 import "./DatesModal.css";
-import { formatDateTime } from "../../utils/date";
+import { formatDateTime, toISODate, toISODatetime } from "../../utils/date";
 
 import { Button } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import CloseIcon from "@mui/icons-material/Close";
 
-export default function ScheduleDatesModal({ dates, removeDate, onClose }) {
-  // 以下のコードとeffectはdates配列の中身が1になった時に削除を押せないようにする目的
-  // 現在、scheduleのdates配列がから配列でも登録されてしまう問題が起きているのでそれを防ぐ目的で定義
+import TimePicker from "../../components/commonPicker/TimePicker";
+
+export default function ScheduleDatesModal({ dates, onClose, onChange }) {
+  // モーダル内部でのみ使用する編集用 state
+  const [internalDates, setInternalDates] = useState([]);
+
+  // dates を初期値として internalDates を生成
+  useEffect(() => {
+    setInternalDates(
+      dates.map((d) => ({
+        date: toISODate(d.start_date), // API用 ISO date (YYYY-MM-DD)
+        start: formatDateTime(d.start_date, "time"), // 表示・編集用 HH:mm
+        end: formatDateTime(d.end_date, "time"), // 表示・編集用 HH:mm
+        _local_id: crypto.randomUUID(),
+      }))
+    );
+  }, [dates]);
+
+  // 日程が1件のみの時、削除を禁止
   const [minimumDates, setMinimumDates] = useState(false);
   useEffect(() => {
-    if (dates.length === 1) {
+    if (internalDates.length === 1) {
       setMinimumDates(true);
     } else {
       setMinimumDates(false);
     }
-  }, [dates.length]);
+  }, [internalDates.length]);
+
+  const handleTimeChange = (localId, field, value) => {
+    setInternalDates((prev) =>
+      prev.map((date) =>
+        date._local_id === localId
+          ? {
+              ...date,
+              [field]: value,
+            }
+          : date
+      )
+    );
+  };
 
   return (
     <div className="dates-modal">
       <div className="dates-modal-contents">
         <h3>登録済み日程</h3>
-        {dates.length === 0 && <p>日程はありません。</p>}
-        {dates.map((date, index) => (
-          <div key={index} className="dates-modal-card">
+
+        {internalDates.length === 0 && <p>日程はありません。</p>}
+
+        {internalDates.map((date) => (
+          <div key={date._local_id} className="dates-modal-card">
             <div style={{ display: "block", marginBottom: "4px" }}>
-              開始: {formatDateTime(date.start_date || "-", "datetime")}
+              日程: {formatDateTime(date.date, "date")}
             </div>
-            <div style={{ display: "block" }}>
-              終了: {formatDateTime(date.end_date || "-", "datetime")}
+
+            <div style={{ display: "block", marginBottom: "4px" }}>
+              <TimePicker
+                label="開始"
+                mode="start"
+                value={date.start}
+                constraintValue={date.end}
+                onChange={(value) =>
+                  handleTimeChange(date._local_id, "start", value)
+                }
+              />
+            </div>
+
+            <div style={{ display: "block", marginBottom: "8px" }}>
+              <TimePicker
+                label="終了"
+                mode="end"
+                value={date.end}
+                constraintValue={date.start}
+                onChange={(value) =>
+                  handleTimeChange(date._local_id, "end", value)
+                }
+              />
             </div>
 
             <Button
               type="button"
               variant="contained"
               startIcon={<DeleteIcon />}
-              onClick={() => removeDate(index)}
+              onClick={() => {
+                setInternalDates((prev) =>
+                  prev.filter((d) => d._local_id !== date._local_id)
+                );
+              }}
               disabled={minimumDates}
             >
               削除
@@ -44,12 +100,22 @@ export default function ScheduleDatesModal({ dates, removeDate, onClose }) {
           </div>
         ))}
 
-        {/* 位置の固定   */}
         <Button
           type="button"
           variant="contained"
           startIcon={<CloseIcon />}
-          onClick={onClose}
+          onClick={() => {
+            if (onChange) {
+              const merged = internalDates.map(
+                ({ _local_id, date, start, end }) => ({
+                  start_date: toISODatetime(date, start),
+                  end_date: toISODatetime(date, end),
+                })
+              );
+              onChange(merged);
+            }
+            onClose();
+          }}
         >
           閉じる
         </Button>

--- a/frontend/src/pages/schedules/ScheduleForm.jsx
+++ b/frontend/src/pages/schedules/ScheduleForm.jsx
@@ -105,9 +105,17 @@ export default function ScheduleForm({
 
       {showDatesModal && (
         <ScheduleDatesModal
-          dates={dates}
+          dates={formData.dates}
           removeDate={removeDate}
           onClose={() => setShowDatesModal(false)}
+          onChange={(newDates) => {
+            onChange({
+              target: {
+                name: "dates",
+                value: newDates,
+              },
+            });
+          }}
         />
       )}
     </BaseForm>

--- a/frontend/src/pages/schedules/useDateTime.js
+++ b/frontend/src/pages/schedules/useDateTime.js
@@ -32,13 +32,20 @@ export function useDateTime(schedules) {
   };
 }
 
-// scheduleのdatesに追加するための関数
+// scheduleのdatesを「追加・削除」するためのUI専用ロジック
+// Single Source of Truth は formData.dates
 export function handleDateTime(formData, onChange) {
   const [dates, setDates] = useState(
-    formData.dates && formData.dates.length > 0
-      ? formData.dates
-      : [{ start_date: "", end_date: "" }]
+    Array.isArray(formData.dates) ? formData.dates : []
   );
+  // formData.dates を唯一の真実として同期する
+  useEffect(() => {
+    if (Array.isArray(formData.dates)) {
+      setDates(formData.dates);
+    } else {
+      setDates([]);
+    }
+  }, [formData.dates]);
   const [selectedDates, setSelectedDates] = useState([]);
   const [start, setStart] = useState("");
   const [end, setEnd] = useState("");

--- a/frontend/src/pages/schedules/useSchedule.js
+++ b/frontend/src/pages/schedules/useSchedule.js
@@ -25,12 +25,7 @@ export function useSchedule(id = null) {
   const [formData, setFormData] = useState({
     title: "",
     note: "",
-    dates: [
-      {
-        start_date: getNowDateTime(),
-        end_date: getNowPlusOneHour(),
-      },
-    ],
+    dates: [],
     category_id: "",
   });
 
@@ -133,16 +128,10 @@ export function useSchedule(id = null) {
 
   // フォームを初期値に戻す
   const resetForm = () => {
-    // setSelectedDates([getNowDateTime().slice(0, 10)]);
     setFormData({
       title: "",
       note: "",
-      dates: [
-        {
-          start_date: getNowDateTime(),
-          end_date: getNowPlusOneHour(),
-        },
-      ],
+      dates: [],
       category_id: "",
     });
   };

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -62,3 +62,61 @@ export function getNowPlusOneHour() {
   now.setHours(now.getHours() + 1);
   return formatLocalDateTime(now);
 }
+
+/*
+====================================================
+API用ヘルパー（非破壊追加）
+----------------------------------------------------
+目的:
+- 表示用フォーマット（formatDateTime）をAPI送信に使わないための安全な経路を提供する
+- 既存関数の役割は一切変更しない
+
+ルール:
+- API送信・保存時は「必ず」このセクションの関数のみを使用する
+- formatDateTime は表示専用（人間向け）としてのみ使用する
+====================================================
+*/
+
+/**
+ * API専用: ISO datetime から ISO date (YYYY-MM-DD) を取り出す
+ * @param {string} isoDatetime - 例: "2026-01-09T07:30:00"
+ * @returns {string} - "2026-01-09"
+ */
+export function toISODate(isoDatetime) {
+  // 先頭10文字を使うことで、表示用ロケール変換を一切通さない
+  return isoDatetime.slice(0, 10);
+}
+
+/**
+ * API専用: ISO date + time(HH:mm) から ISO datetime を組み立てる
+ * @param {string} isoDate - "YYYY-MM-DD"
+ * @param {string} time - "HH:mm"
+ * @returns {string} - "YYYY-MM-DDTHH:mm:00"
+ */
+export function toISODatetime(isoDate, time) {
+  return `${isoDate}T${time}:00`;
+}
+
+/*
+----------------------------------------------------
+使い方例（コメントアウト／参考）
+----------------------------------------------------
+
+// 【DatesModal 初期化時】
+// 表示は formatDateTime、内部データは ISO を保持
+// import { toISODate, formatDateTime } from "@/utils/date";
+//
+// const isoDate = toISODate(d.start_date);     // "2026-01-09"
+// const start = formatDateTime(d.start_date, "time"); // "07:30"
+// const end   = formatDateTime(d.end_date, "time");   // "08:30"
+
+// 【保存時（親コンポーネント）】
+// import { toISODatetime } from "@/utils/date";
+//
+// const payload = {
+//   dates: formData.dates.map(d => ({
+//     start_date: toISODatetime(d.date, d.start),
+//     end_date:   toISODatetime(d.date, d.end),
+//   })),
+// };
+*/


### PR DESCRIPTION
# 登録済み予定から個別に時刻を編集可能にした

## 1. 目的

- 不規則な予定の時刻の側面に対応するため

---

## 2. 機能

- 登録済み予定から個別に時刻をいじれる
- モーダルを閉じると反映される 

---

## 3. 効果

- 時刻が違うだけで、別の予定として再度登録する作業の回数が減る
- 登録にかかる時間の短縮

---

