### PR TITLE
2つの修正

### DIFF
--- a/backend/app/crud/schedule.py
+++ b/backend/app/crud/schedule.py
@@ -10,18 +10,22 @@ class ScheduleRepository(BaseRepository):
         super().__init__(db, Schedule)
 
     # --- 作成 ---
-    # スケジュールの予定はdatesモデルも絡んでいるため、base_create_instanceの導入は見送り
     def create(self, user_id: UUID, schedule_in: ScheduleCreate) -> Schedule:
-        schedule = Schedule(
-            title=schedule_in.title,
-            note=schedule_in.note,
-            dates=[
-                ScheduleDate(start_date=d.start_date, end_date=d.end_date)
-                for d in schedule_in.dates
-            ],
-            category_id=schedule_in.category_id,  # Enum → str
-            user_id=user_id,
+        schedule = self.base_create_instance(
+            model=self.model,
+            schema_in=schedule_in,
+            extra={
+                "user_id": user_id,
+                "dates": [
+                    ScheduleDate(
+                        start_date=d.start_date,
+                        end_date=d.end_date,
+                    )
+                    for d in schedule_in.dates
+                ],
+            },
         )
+
         return self.base_add(schedule)
 
     # --- 取得（ID指定） ---

--- a/tests/user/test_passkey.py
+++ b/tests/user/test_passkey.py
@@ -12,7 +12,6 @@ from app.models.passkey import Passkey
 import json
 import base64
 
-
 # =========================
 # Test: register/options
 # =========================
@@ -49,41 +48,6 @@ def test_register_options_success(raw_client, db_session):
 
     assert challenge is not None
     assert challenge.type == "register"
-
-
-def test_register_options_duplicate_passkey(raw_client, db_session):
-    """
-    異常系:
-    - 既にpasskey登録済みユーザー
-    - 409 PASSKEY_ALREADY_REGISTERED
-    """
-
-    email = f"test-{uuid4()}@example.com"
-
-    # 事前にUser作成
-    user = User(email=email)
-    db_session.add(user)
-    db_session.commit()
-    db_session.refresh(user)
-
-    credential_id = str(uuid4())
-    passkey = Passkey(
-        user_id=user.id,
-        credential_id=credential_id,
-        public_key=b"dummy",
-        sign_count=1,
-        transports=None,
-    )
-    db_session.add(passkey)
-    db_session.commit()
-
-    res = raw_client.post(
-        "/auth/passkey/register/options",
-        json={"email": email},
-    )
-
-    assert res.status_code == 409
-    assert res.json()["code"] == "PASSKEY_ALREADY_REGISTERED"
 
 
 # =========================
@@ -219,7 +183,7 @@ def test_login_options_success(raw_client, db_session):
     passkey = Passkey(
         user_id=user.id,
         credential_id=credential_id,
-        public_key=b"dummy",
+        public_key=base64.urlsafe_b64encode(b"fake_public_key").decode(),
         sign_count=1,
         transports=None,
     )
@@ -314,7 +278,7 @@ def test_login_verify_success(raw_client, db_session, monkeypatch):
     passkey = Passkey(
         user_id=user.id,
         credential_id=credential_id,
-        public_key=b"dummy",
+        public_key=base64.urlsafe_b64encode(b"fake_public_key").decode(),
         sign_count=1,
         transports=None,
     )
@@ -336,6 +300,7 @@ def test_login_verify_success(raw_client, db_session, monkeypatch):
         new_sign_count = 2
 
     def fake_verify_authentication(*args, **kwargs):
+        print("MOCK CALLED")
         return FakeAuthenticationResult()
 
     monkeypatch.setattr(
@@ -406,7 +371,7 @@ def test_login_verify_sign_count_replay(raw_client, db_session, monkeypatch):
     passkey = Passkey(
         user_id=user.id,
         credential_id=credential_id,
-        public_key=b"dummy",
+        public_key=base64.urlsafe_b64encode(b"fake_public_key").decode(),
         sign_count=2,
         transports=None,
     )
@@ -484,7 +449,7 @@ def test_register_verify_duplicate_credential(raw_client, db_session, monkeypatc
     existing = Passkey(
         user_id=user.id,
         credential_id=credential_id,
-        public_key=b"dummy",
+        public_key=base64.urlsafe_b64encode(b"fake_public_key").decode(),
         sign_count=1,
         transports=None,
     )
@@ -492,7 +457,7 @@ def test_register_verify_duplicate_credential(raw_client, db_session, monkeypatc
     db_session.commit()
 
     class FakeRegistrationResult:
-        credential_public_key = b"fake"
+        credential_public_key = base64.urlsafe_b64encode(b"fake_public_key").decode()
         sign_count = 1
 
     def fake_verify_registration(*args, **kwargs):
@@ -540,7 +505,7 @@ def test_login_verify_challenge_not_found(raw_client, db_session):
     passkey = Passkey(
         user_id=user.id,
         credential_id=credential_id,
-        public_key=b"dummy",
+        public_key=base64.urlsafe_b64encode(b"fake_public_key").decode(),
         sign_count=1,
         transports=None,
     )


### PR DESCRIPTION
## 修正内容

### base_create_instanceの適用

元々別リレーションの追加も含めていたため、scheduleモデルだけ採用を見送っていた。

しかしextra引数を使用することで、別リレーションの対応が可能だと判明し適用を決断

テスト、実アプリの動作でも問題ないことを確認

### テストのずれの修正

1. register_optionsでパスキー重複のチェックをしないが、テストではチェックしていたものがあり、それを削除した
2. login_verifyでの**public_key**の値を以下に修正。

```python
public_key=base64.urlsafe_b64encode(b"fake_public_key").decode()
```